### PR TITLE
feat: onboarding — Siri setup screen, exit button, skip firstCapture on replay

### DIFF
--- a/Sources/STASHApp.swift
+++ b/Sources/STASHApp.swift
@@ -25,6 +25,7 @@ struct STASHApp: App {
     // MARK: - Onboarding
 
     @State private var showOnboarding = false
+    @State private var isReplayOnboarding = false
 
     // MARK: - Services (Shared Instances)
 
@@ -61,6 +62,7 @@ struct STASHApp: App {
                 .fullScreenCover(isPresented: $showOnboarding) {
                     OnboardingScreen(
                         viewModel: OnboardingViewModel(
+                            isReplay: isReplayOnboarding,
                             captureViewModel: CaptureViewModel(
                                 thoughtService: ThoughtService.shared,
                                 contextService: ContextService.shared,
@@ -70,6 +72,7 @@ struct STASHApp: App {
                             ),
                             onComplete: {
                                 showOnboarding = false
+                                isReplayOnboarding = false
                             }
                         )
                     )
@@ -78,6 +81,7 @@ struct STASHApp: App {
                 .onReceive(NotificationCenter.default.publisher(for: .replayOnboarding)) { _ in
                     _Concurrency.Task { @MainActor in
                         OnboardingViewModel.resetOnboarding()
+                        isReplayOnboarding = true
                         showOnboarding = true
                     }
                 }

--- a/Sources/UI/Onboarding/OnboardingCopy.swift
+++ b/Sources/UI/Onboarding/OnboardingCopy.swift
@@ -161,6 +161,23 @@ enum OnboardingCopy {
         }
     }
 
+    static func siriSetupIntro(for persona: SquirrelPersona) -> String {
+        switch persona.id {
+        case SquirrelPersona.supportiveListener.id:
+            return "You can reach me from anywhere — even without opening the app. Just tell Siri, and I'll catch it for you."
+        case SquirrelPersona.brainstormPartner.id:
+            return "Best ideas happen mid-run, mid-drive, mid-shower. Set this up so we never lose one."
+        case SquirrelPersona.socraticQuestioner.id:
+            return "What's the cost of a thought that slips away? Set this up so you can capture from anywhere."
+        case SquirrelPersona.journalGuide.id:
+            return "Sometimes a moment needs to be held right as it happens. This lets you do that hands-free."
+        case SquirrelPersona.devilsAdvocate.id:
+            return "You're going to forget it. You always do. Unless you tell Siri right now."
+        default:
+            return "Capture thoughts anywhere — just tell Siri."
+        }
+    }
+
     static func completionMessage(for persona: SquirrelPersona) -> String {
         switch persona.id {
         case SquirrelPersona.supportiveListener.id:

--- a/Sources/UI/Onboarding/OnboardingCopy.swift
+++ b/Sources/UI/Onboarding/OnboardingCopy.swift
@@ -147,17 +147,17 @@ enum OnboardingCopy {
     static func futureTeaser(for persona: SquirrelPersona) -> String {
         switch persona.id {
         case SquirrelPersona.supportiveListener.id:
-            return "Some of your thoughts will earn 'shiny' status—the ones with strong feelings, tasks, or connections. I'll help you spot them on your home screen. ✨"
+            return "Soon I'll start surfacing your most meaningful thoughts—the ones with strong feelings, tasks, or real connections. The ones worth a second look. ✨"
         case SquirrelPersona.brainstormPartner.id:
-            return "SHINY THOUGHTS! The vault surfaces your best ideas automatically—the ones with tasks, connections, or strong vibes. Check 'Today's Shiny' daily! ✨"
+            return "SHINY THOUGHTS ARE COMING! Soon the vault will automatically spot your best ideas—the ones with tasks, connections, or strong vibes. Can't wait! ✨"
         case SquirrelPersona.socraticQuestioner.id:
-            return "Shiny thoughts: scored on sentiment, actionability, connections, and time depth. The algorithm picks your high-signal captures. Worth examining what it values. ✨"
+            return "Coming next: a scoring system for your captures—sentiment, actionability, connections, depth. Worth asking now what you think makes a thought worth revisiting. ✨"
         case SquirrelPersona.journalGuide.id:
-            return "Certain thoughts will glow brighter—the ones carrying emotion, action, or connection. We'll notice them together in 'Today's Shiny.' ✨"
+            return "Soon, certain thoughts will glow a little brighter—the ones carrying real emotion, action, or connection. We'll find them together. ✨"
         case SquirrelPersona.devilsAdvocate.id:
-            return "Shiny thoughts: algorithmic ranking of your 'best' captures. Based on sentiment, tasks, connections, energy. Could surface gems. Could miss what matters. ✨"
+            return "Not built yet. But coming: an algorithm that ranks what you've captured. Sentiment, tasks, connections, energy. We'll see if the machine knows what matters to you. ✨"
         default:
-            return "Shiny thoughts—your most meaningful captures, automatically surfaced daily based on emotion, action, and connection. ✨"
+            return "Coming soon: shiny thoughts—your most meaningful captures will be automatically surfaced based on emotion, action, and connection. ✨"
         }
     }
 

--- a/Sources/UI/Onboarding/OnboardingCopy.swift
+++ b/Sources/UI/Onboarding/OnboardingCopy.swift
@@ -147,17 +147,17 @@ enum OnboardingCopy {
     static func futureTeaser(for persona: SquirrelPersona) -> String {
         switch persona.id {
         case SquirrelPersona.supportiveListener.id:
-            return "Soon I'll start surfacing your most meaningful thoughts—the ones with strong feelings, tasks, or real connections. The ones worth a second look. ✨"
+            return "Some of your thoughts will earn 'shiny' status—the ones with strong feelings, tasks, or connections. I'll help you spot them on your home screen. ✨"
         case SquirrelPersona.brainstormPartner.id:
-            return "SHINY THOUGHTS ARE COMING! Soon the vault will automatically spot your best ideas—the ones with tasks, connections, or strong vibes. Can't wait! ✨"
+            return "SHINY THOUGHTS! The vault surfaces your best ideas automatically—the ones with tasks, connections, or strong vibes. Check 'Today's Shiny' daily! ✨"
         case SquirrelPersona.socraticQuestioner.id:
-            return "Coming next: a scoring system for your captures—sentiment, actionability, connections, depth. Worth asking now what you think makes a thought worth revisiting. ✨"
+            return "Shiny thoughts: scored on sentiment, actionability, connections, and time depth. The algorithm picks your high-signal captures. Worth examining what it values. ✨"
         case SquirrelPersona.journalGuide.id:
-            return "Soon, certain thoughts will glow a little brighter—the ones carrying real emotion, action, or connection. We'll find them together. ✨"
+            return "Certain thoughts will glow brighter—the ones carrying emotion, action, or connection. We'll notice them together in 'Today's Shiny.' ✨"
         case SquirrelPersona.devilsAdvocate.id:
-            return "Not built yet. But coming: an algorithm that ranks what you've captured. Sentiment, tasks, connections, energy. We'll see if the machine knows what matters to you. ✨"
+            return "Shiny thoughts: algorithmic ranking of your 'best' captures. Based on sentiment, tasks, connections, energy. Could surface gems. Could miss what matters. ✨"
         default:
-            return "Coming soon: shiny thoughts—your most meaningful captures will be automatically surfaced based on emotion, action, and connection. ✨"
+            return "Shiny thoughts—your most meaningful captures, automatically surfaced daily based on emotion, action, and connection. ✨"
         }
     }
 

--- a/Sources/UI/Onboarding/Steps/FirstCaptureStepView.swift
+++ b/Sources/UI/Onboarding/Steps/FirstCaptureStepView.swift
@@ -44,6 +44,16 @@ struct FirstCaptureStepView: View {
                         viewModel.completeCapture()
                     }
                 }
+
+            // Skip option
+            Button {
+                viewModel.skip()
+            } label: {
+                Text("Skip for now")
+                    .font(.subheadline)
+                    .foregroundStyle(theme.secondaryTextColor)
+            }
+            .padding(.bottom, 16)
         }
     }
 }

--- a/Sources/UI/Onboarding/Steps/FutureTeaserStepView.swift
+++ b/Sources/UI/Onboarding/Steps/FutureTeaserStepView.swift
@@ -2,7 +2,7 @@
 //  FutureTeaserStepView.swift
 //  STASH
 //
-//  Onboarding Step 8: Preview of future shiny thoughts feature
+//  Onboarding Step 8: Introduces the Shiny Thoughts feature
 //
 
 import SwiftUI
@@ -43,7 +43,7 @@ struct FutureTeaserStepView: View {
 
             // Feature preview
             VStack(spacing: 16) {
-                Text("Coming Soon")
+                Text("Shiny Thoughts")
                     .font(.largeTitle)
                     .fontWeight(.bold)
                     .foregroundStyle(theme.textColor)
@@ -54,7 +54,7 @@ struct FutureTeaserStepView: View {
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, 32)
 
-                // Mock shiny thought preview
+                // Shiny thought preview
                 VStack(alignment: .leading, spacing: 8) {
                     HStack {
                         Image(systemName: "sparkles")
@@ -66,7 +66,7 @@ struct FutureTeaserStepView: View {
                         Spacer()
                     }
 
-                    Text("Your most insightful captures will be automatically surfaced here...")
+                    Text("Your most insightful captures are automatically surfaced in \"Today's Shiny\" on Browse.")
                         .font(.subheadline)
                         .foregroundStyle(theme.textColor)
                         .lineLimit(3)

--- a/Sources/UI/Onboarding/Steps/SiriSetupStepView.swift
+++ b/Sources/UI/Onboarding/Steps/SiriSetupStepView.swift
@@ -1,0 +1,96 @@
+//
+//  SiriSetupStepView.swift
+//  STASH
+//
+//  Onboarding step: teaches user the Siri phrases for voice capture.
+//
+
+import SwiftUI
+
+struct SiriSetupStepView: View {
+    let persona: SquirrelPersona
+    let onContinue: () -> Void
+
+    private let phrases = [
+        "Hey Siri, stash a thought",
+        "Hey Siri, stash a thought in STASH",
+        "Hey Siri, save a note in STASH",
+        "Hey Siri, remember something in STASH",
+    ]
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            // Icon
+            Image(systemName: "waveform")
+                .font(.system(size: 56))
+                .foregroundStyle(.purple)
+
+            // Persona-voiced intro
+            VStack(spacing: 8) {
+                Text("Talk to Siri")
+                    .font(.title2)
+                    .fontWeight(.bold)
+
+                Text(OnboardingCopy.siriSetupIntro(for: persona))
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+            }
+
+            // Phrase chips
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Pick whichever feels natural — all of them work.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 4)
+                    .padding(.bottom, 12)
+
+                VStack(spacing: 10) {
+                    ForEach(phrases, id: \.self) { phrase in
+                        HStack {
+                            Image(systemName: "mic.fill")
+                                .font(.caption)
+                                .foregroundStyle(.purple)
+                            Text(phrase)
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                            Spacer()
+                        }
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 12)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(Color(.secondarySystemBackground))
+                        )
+                    }
+                }
+            }
+            .padding(.horizontal)
+
+            Spacer()
+
+            // CTA
+            Button(action: onContinue) {
+                Text("Got it")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.accentColor)
+                    .foregroundStyle(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 14))
+            }
+            .padding(.horizontal)
+            .padding(.bottom)
+        }
+    }
+}
+
+#Preview {
+    SiriSetupStepView(
+        persona: SquirrelPersona.supportiveListener,
+        onContinue: {}
+    )
+}

--- a/Sources/UI/Screens/OnboardingScreen.swift
+++ b/Sources/UI/Screens/OnboardingScreen.swift
@@ -63,6 +63,19 @@ struct OnboardingScreen: View {
         }
         .preferredColorScheme(theme.preferredColorScheme)
         .animation(.easeInOut(duration: 0.3), value: viewModel.currentStep)
+        .overlay(alignment: .topTrailing) {
+            if viewModel.currentStep != .welcome && viewModel.currentStep != .completion {
+                Button {
+                    viewModel.completeOnboarding()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundStyle(.tertiary)
+                        .padding(16)
+                }
+                .accessibilityLabel("Exit tutorial")
+            }
+        }
     }
 
     // MARK: - Step Routing

--- a/Sources/UI/Screens/OnboardingScreen.swift
+++ b/Sources/UI/Screens/OnboardingScreen.swift
@@ -86,6 +86,11 @@ struct OnboardingScreen: View {
             NotificationsStepView(viewModel: viewModel)
         case .futureTeaser:
             FutureTeaserStepView(viewModel: viewModel)
+        case .siriSetup:
+            SiriSetupStepView(
+                persona: viewModel.selectedPersona,
+                onContinue: { viewModel.advance() }
+            )
         case .completion:
             CompletionStepView(viewModel: viewModel)
         }

--- a/Sources/UI/ViewModels/OnboardingViewModel.swift
+++ b/Sources/UI/ViewModels/OnboardingViewModel.swift
@@ -13,15 +13,16 @@ import SwiftUI
 // MARK: - Onboarding Step
 
 enum OnboardingStep: Int, CaseIterable {
-    case welcome = 0
+    case welcome       = 0
     case personaPicker = 1
-    case firstCapture = 2
+    case firstCapture  = 2
     case acornExplainer = 3
-    case streakIntro = 4
-    case permissions = 5
+    case streakIntro   = 4
+    case permissions   = 5
     case notifications = 6
-    case futureTeaser = 7
-    case completion = 8
+    case futureTeaser  = 7
+    case siriSetup     = 8
+    case completion    = 9
 
     var canSkip: Bool {
         switch self {
@@ -73,15 +74,20 @@ final class OnboardingViewModel {
     // Embedded CaptureViewModel for step 3 (real capture)
     let captureViewModel: CaptureViewModel
 
+    /// Whether this is a replay of the tutorial (skips firstCapture step)
+    let isReplay: Bool
+
     // MARK: - Initialization
 
     init(
+        isReplay: Bool = false,
         personaService: PersonaService = .shared,
         permissionCoordinator: PermissionCoordinator = .shared,
         reminderService: SquirrelReminderService = .shared,
         captureViewModel: CaptureViewModel,
         onComplete: @escaping () -> Void
     ) {
+        self.isReplay = isReplay
         self.personaService = personaService
         self.permissionCoordinator = permissionCoordinator
         self.reminderService = reminderService
@@ -104,6 +110,14 @@ final class OnboardingViewModel {
         guard let nextStep = OnboardingStep(rawValue: currentStep.rawValue + 1) else {
             // Reached the end
             completeOnboarding()
+            return
+        }
+
+        // Skip firstCapture when replaying — user has already done this
+        if nextStep == .firstCapture && isReplay {
+            withAnimation(.easeInOut(duration: 0.3)) {
+                currentStep = .acornExplainer
+            }
             return
         }
 

--- a/docs/plans/2026-02-24-onboarding-siri-exit-design.md
+++ b/docs/plans/2026-02-24-onboarding-siri-exit-design.md
@@ -1,0 +1,83 @@
+# Onboarding: Siri Screen, Exit Button, Skip FirstCapture on Replay
+
+**Date:** 2026-02-24
+**Status:** Approved
+
+---
+
+## Changes
+
+### 1. Siri Setup Screen (new step)
+
+New `OnboardingStep.siriSetup` inserted between `futureTeaser` and `completion`.
+Step enum shifts: siriSetup = 8, completion = 9.
+
+**Content:**
+- Persona-voiced intro (added to `OnboardingCopy`)
+- Subline: "Works from anywhere — locked screen, AirPods, CarPlay"
+- 4 phrase chips in a stacked card list:
+  1. "Hey Siri, stash a thought"
+  2. "Hey Siri, stash a thought in STASH"
+  3. "Hey Siri, save a note in STASH"
+  4. "Hey Siri, remember something in STASH"
+- Persona copy above list: something like "pick whichever feels natural — all of them work"
+- No API call needed; phrases are already registered via `ThoughtAppShortcuts.updateAppShortcutParameters()` at launch
+
+**Files to create:** `Sources/UI/Onboarding/Steps/SiriSetupStepView.swift`
+**Files to modify:** `OnboardingCopy.swift` (add `siriSetupIntro(for:)`), `OnboardingScreen.swift` (add case), `OnboardingViewModel.swift` (add step)
+
+---
+
+### 2. Exit Button
+
+- Shown on steps 1–8 (personaPicker through siriSetup); hidden on welcome (0) and completion (9)
+- Top-right corner, "×" or `xmark` SF Symbol
+- Tertiary text color — visually quiet, not competing with primary CTA
+- Action: calls `completeOnboarding()` then `onComplete()`
+  - Marks `onboarding.completed = true` in UserDefaults
+  - Fires `onboardingCompleted` analytics event
+  - Dismisses the screen
+
+**Files to modify:** `OnboardingScreen.swift` (add button to overlay/toolbar)
+
+---
+
+### 3. Skip firstCapture on Replay
+
+`OnboardingViewModel` gains `isReplay: Bool` parameter.
+
+When `isReplay == true`, `advance()` skips over `.firstCapture` automatically (steps from personaPicker directly to acornExplainer).
+
+`MainTabView` gains `@State var isReplayOnboarding = false`.
+
+Replay notification handler:
+```swift
+.onReceive(NotificationCenter.default.publisher(for: .replayOnboarding)) { _ in
+    _Concurrency.Task { @MainActor in
+        OnboardingViewModel.resetOnboarding()
+        isReplayOnboarding = true
+        showOnboarding = true
+    }
+}
+```
+
+`fullScreenCover` passes `isReplay: isReplayOnboarding` when constructing the ViewModel, then resets `isReplayOnboarding = false` in `onComplete`.
+
+**Files to modify:** `OnboardingViewModel.swift`, `STASHApp.swift`
+
+---
+
+## Step Sequence After Changes
+
+| # | Step | Progress dot | Exit visible |
+|---|------|-------------|--------------|
+| 0 | welcome | no | no |
+| 1 | personaPicker | yes | yes |
+| 2 | firstCapture | yes | yes (skipped on replay) |
+| 3 | acornExplainer | yes | yes |
+| 4 | streakIntro | yes | yes |
+| 5 | permissions | yes | yes |
+| 6 | notifications | yes | yes |
+| 7 | futureTeaser | yes | yes |
+| 8 | siriSetup | yes | yes |
+| 9 | completion | no | no |

--- a/docs/plans/2026-02-24-onboarding-siri-exit.md
+++ b/docs/plans/2026-02-24-onboarding-siri-exit.md
@@ -1,0 +1,431 @@
+# Onboarding: Siri Screen, Exit Button, Skip FirstCapture on Replay
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a Siri setup screen to onboarding, an exit button on all mid-flow steps, and skip the first-capture step when replaying the tutorial.
+
+**Architecture:** Three independent changes to the existing enum-based onboarding state machine. The step enum gains one new case (siriSetup at position 8, completion shifts to 9). OnboardingViewModel gains an `isReplay` flag used to skip `.firstCapture` in `advance()`. The exit button is a single overlay addition to `OnboardingScreen`.
+
+**Tech Stack:** SwiftUI, @Observable, UserDefaults, existing OnboardingStep enum
+
+---
+
+### Task 1: Add siriSetupIntro copy to OnboardingCopy
+
+**Files:**
+- Modify: `Sources/UI/Onboarding/OnboardingCopy.swift` (after line 162, before completionMessage)
+
+**Step 1: Add the static function**
+
+Add after `futureTeaser(for:)` (after line 162):
+
+```swift
+static func siriSetupIntro(for persona: SquirrelPersona) -> String {
+    switch persona.id {
+    case "supportiveListener":
+        return "You can reach me from anywhere — even without opening the app. Just tell Siri, and I'll catch it for you."
+    case "brainstormPartner":
+        return "Best ideas happen mid-run, mid-drive, mid-shower. Set this up so we never lose one."
+    case "socraticQuestioner":
+        return "What's the cost of a thought that slips away? Set this up so you can capture from anywhere."
+    case "journalGuide":
+        return "Sometimes a moment needs to be held right as it happens. This lets you do that hands-free."
+    case "devilsAdvocate":
+        return "You're going to forget it. You always do. Unless you tell Siri right now."
+    default:
+        return "Capture thoughts anywhere — just tell Siri."
+    }
+}
+```
+
+**Step 2: Build to verify no errors**
+
+```bash
+xcodebuild -scheme STASH -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build 2>&1 | grep -E "(error:|BUILD)"
+```
+Expected: `BUILD SUCCEEDED`
+
+**Step 3: Commit**
+
+```bash
+git add Sources/UI/Onboarding/OnboardingCopy.swift
+git commit -m "feat: add siriSetupIntro copy to OnboardingCopy"
+```
+
+---
+
+### Task 2: Create SiriSetupStepView
+
+**Files:**
+- Create: `Sources/UI/Onboarding/Steps/SiriSetupStepView.swift`
+
+**Step 1: Create the file**
+
+```swift
+//
+//  SiriSetupStepView.swift
+//  STASH
+//
+//  Onboarding step: teaches user the Siri phrases for voice capture.
+//
+
+import SwiftUI
+
+struct SiriSetupStepView: View {
+    let persona: SquirrelPersona
+    let onContinue: () -> Void
+
+    private let phrases = [
+        "Hey Siri, stash a thought",
+        "Hey Siri, stash a thought in STASH",
+        "Hey Siri, save a note in STASH",
+        "Hey Siri, remember something in STASH",
+    ]
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            // Icon
+            Image(systemName: "waveform")
+                .font(.system(size: 56))
+                .foregroundStyle(.purple)
+
+            // Persona-voiced intro
+            VStack(spacing: 8) {
+                Text("Talk to Siri")
+                    .font(.title2)
+                    .fontWeight(.bold)
+
+                Text(OnboardingCopy.siriSetupIntro(for: persona))
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+            }
+
+            // Phrase chips
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Pick whichever feels natural — all of them work.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 4)
+                    .padding(.bottom, 12)
+
+                VStack(spacing: 10) {
+                    ForEach(phrases, id: \.self) { phrase in
+                        HStack {
+                            Image(systemName: "mic.fill")
+                                .font(.caption)
+                                .foregroundStyle(.purple)
+                            Text(phrase)
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                            Spacer()
+                        }
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 12)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(Color(.secondarySystemBackground))
+                        )
+                    }
+                }
+            }
+            .padding(.horizontal)
+
+            Spacer()
+
+            // CTA
+            Button(action: onContinue) {
+                Text("Got it")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.accentColor)
+                    .foregroundStyle(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 14))
+            }
+            .padding(.horizontal)
+            .padding(.bottom)
+        }
+    }
+}
+
+#Preview {
+    SiriSetupStepView(
+        persona: SquirrelPersona(
+            id: "supportiveListener",
+            name: "Supportive Listener",
+            emoji: "🐿️",
+            systemPrompt: "",
+            colorHex: "#A78BFA",
+            isCustom: false,
+            isDefault: true,
+            createdAt: Date()
+        ),
+        onContinue: {}
+    )
+}
+```
+
+**Step 2: Build**
+
+```bash
+xcodebuild -scheme STASH -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build 2>&1 | grep -E "(error:|BUILD)"
+```
+Expected: `BUILD SUCCEEDED`
+
+**Step 3: Commit**
+
+```bash
+git add Sources/UI/Onboarding/Steps/SiriSetupStepView.swift
+git commit -m "feat: add SiriSetupStepView"
+```
+
+---
+
+### Task 3: Add siriSetup to OnboardingStep enum and update OnboardingViewModel
+
+**Files:**
+- Modify: `Sources/UI/ViewModels/OnboardingViewModel.swift`
+
+**Step 1: Update the OnboardingStep enum**
+
+Replace the current enum cases (lines 16–24). Add `siriSetup` before `completion` and shift `completion` to 9:
+
+```swift
+enum OnboardingStep: Int, CaseIterable {
+    case welcome       = 0
+    case personaPicker = 1
+    case firstCapture  = 2
+    case acornExplainer = 3
+    case streakIntro   = 4
+    case permissions   = 5
+    case notifications = 6
+    case futureTeaser  = 7
+    case siriSetup     = 8
+    case completion    = 9
+}
+```
+
+**Step 2: Update showProgressDots**
+
+The existing `showProgressDots` returns `false` for `.welcome` and `.completion`. Verify it still compiles cleanly — no change needed since it only excludes by name.
+
+**Step 3: Add isReplay property and update init**
+
+Add `isReplay: Bool = false` property and init parameter:
+
+```swift
+// In the state properties section (around line 49), add:
+let isReplay: Bool
+
+// Update init signature (line 78):
+init(
+    isReplay: Bool = false,
+    personaService: SquirrelPersonaService = .shared,
+    permissionCoordinator: PermissionCoordinator = .shared,
+    reminderService: SquirrelReminderService = .shared,
+    captureViewModel: CaptureViewModel,
+    onComplete: @escaping () -> Void
+) {
+    self.isReplay = isReplay
+    // ...rest of existing init body unchanged
+}
+```
+
+**Step 4: Update advance() to skip firstCapture on replay**
+
+Find `advance()` (line 103). After the animation block opens, add the skip logic:
+
+```swift
+func advance() {
+    guard let next = OnboardingStep(rawValue: currentStep.rawValue + 1) else {
+        completeOnboarding()
+        return
+    }
+    // Skip firstCapture when replaying — user has already done this
+    if next == .firstCapture && isReplay {
+        withAnimation(.easeInOut(duration: 0.3)) {
+            currentStep = .acornExplainer
+        }
+        return
+    }
+    withAnimation(.easeInOut(duration: 0.3)) {
+        currentStep = next
+    }
+    if currentStep == .completion {
+        completeOnboarding()
+    }
+}
+```
+
+Note: Preserve the existing animation and completeOnboarding logic exactly — only add the isReplay guard.
+
+**Step 5: Build**
+
+```bash
+xcodebuild -scheme STASH -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build 2>&1 | grep -E "(error:|BUILD)"
+```
+Expected: `BUILD SUCCEEDED`
+
+**Step 6: Commit**
+
+```bash
+git add Sources/UI/ViewModels/OnboardingViewModel.swift
+git commit -m "feat: add siriSetup step and isReplay to OnboardingViewModel"
+```
+
+---
+
+### Task 4: Wire siriSetup into OnboardingScreen and add exit button
+
+**Files:**
+- Modify: `Sources/UI/Screens/OnboardingScreen.swift`
+
+**Step 1: Add siriSetup case to stepView**
+
+In the `stepView` switch (around line 72), add before the `.completion` case:
+
+```swift
+case .siriSetup:
+    SiriSetupStepView(
+        persona: viewModel.selectedPersona,
+        onContinue: { viewModel.advance() }
+    )
+```
+
+**Step 2: Add exit button overlay**
+
+The top-level `ZStack` or `VStack` in `OnboardingScreen.body` needs an exit button overlay. Add it as an overlay on the outermost container, shown only when the step is not `.welcome` and not `.completion`:
+
+```swift
+// Add this inside the body, as an overlay on the main ZStack/VStack:
+.overlay(alignment: .topTrailing) {
+    if viewModel.currentStep != .welcome && viewModel.currentStep != .completion {
+        Button {
+            viewModel.completeOnboarding()
+        } label: {
+            Image(systemName: "xmark")
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(.tertiary)
+                .padding(16)
+        }
+        .accessibilityLabel("Exit tutorial")
+    }
+}
+```
+
+Note: `completeOnboarding()` is currently `private`. Check — if it is, change it to `internal` (remove the `private` modifier) so `OnboardingScreen` can call it. The exit button calling `completeOnboarding()` directly is intentional: it marks the tutorial done and fires analytics.
+
+**Step 3: Build**
+
+```bash
+xcodebuild -scheme STASH -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build 2>&1 | grep -E "(error:|BUILD)"
+```
+Expected: `BUILD SUCCEEDED`
+
+**Step 4: Commit**
+
+```bash
+git add Sources/UI/Screens/OnboardingScreen.swift
+git commit -m "feat: wire siriSetup step and add exit button to OnboardingScreen"
+```
+
+---
+
+### Task 5: Update STASHApp to pass isReplay when replaying
+
+**Files:**
+- Modify: `Sources/STASHApp.swift`
+
+**Step 1: Add isReplayOnboarding state to STASHApp**
+
+In `STASHApp` (around line 27, near `showOnboarding`):
+
+```swift
+@State private var isReplayOnboarding = false
+```
+
+**Step 2: Update the fullScreenCover to pass isReplay**
+
+In the `fullScreenCover` (around line 61), update the `OnboardingViewModel` init:
+
+```swift
+viewModel: OnboardingViewModel(
+    isReplay: isReplayOnboarding,
+    captureViewModel: CaptureViewModel(
+        thoughtService: ThoughtService.shared,
+        contextService: ContextService.shared,
+        classificationService: ClassificationService.shared,
+        fineTuningService: FineTuningService.shared,
+        taskService: TaskService.shared
+    ),
+    onComplete: {
+        showOnboarding = false
+        isReplayOnboarding = false
+    }
+)
+```
+
+**Step 3: Update the replayOnboarding handler**
+
+Find the `.onReceive` handler (around line 78):
+
+```swift
+.onReceive(NotificationCenter.default.publisher(for: .replayOnboarding)) { _ in
+    _Concurrency.Task { @MainActor in
+        OnboardingViewModel.resetOnboarding()
+        isReplayOnboarding = true
+        showOnboarding = true
+    }
+}
+```
+
+**Step 4: Build**
+
+```bash
+xcodebuild -scheme STASH -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build 2>&1 | grep -E "(error:|BUILD)"
+```
+Expected: `BUILD SUCCEEDED`
+
+**Step 5: Commit**
+
+```bash
+git add Sources/STASHApp.swift
+git commit -m "feat: pass isReplay to OnboardingViewModel on tutorial replay"
+```
+
+---
+
+### Task 6: Final verification
+
+**Step 1: Full build**
+
+```bash
+xcodebuild -scheme STASH -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build 2>&1 | grep -E "(error:|warning:|BUILD)"
+```
+Expected: `BUILD SUCCEEDED`, no new errors.
+
+**Step 2: Manual test checklist**
+
+First-run flow:
+- [ ] All 10 steps appear in order (welcome → … → siriSetup → completion)
+- [ ] firstCapture step appears on first run
+- [ ] Exit × button visible on steps 1–8, hidden on welcome and completion
+- [ ] Tapping × dismisses onboarding and does not show it again on next launch
+- [ ] Siri screen shows all 4 phrases with mic icon
+- [ ] Progress dots count matches step count
+
+Replay flow (Settings → Replay Onboarding):
+- [ ] firstCapture step is skipped (jumps from personaPicker to acornExplainer)
+- [ ] siriSetup still appears
+- [ ] Exit × still works
+- [ ] Replay doesn't break normal flow on subsequent first-run simulator reset
+
+**Step 3: Push branch**
+
+```bash
+git push origin feature/onboarding-siri-exit
+```


### PR DESCRIPTION
## Summary
- New **Siri Setup** step (step 8) with 4 phrase chips and persona-voiced intro, teaching users how to capture via Siri from anywhere
- **Exit button** (×) on all mid-flow steps (1–8); hidden on welcome and completion; calls `completeOnboarding()` to mark tutorial done and dismiss
- **Skip firstCapture on replay** — `OnboardingViewModel` gains `isReplay: Bool`; when replaying from Settings, the first-capture step is automatically skipped
- **Skip button** on the first-capture step so users can skip it even on first run
- **Shinies copy fix** — removed stale "Coming Soon" label; Shiny Thoughts is a live feature

## Test Plan
- [ ] First run: all 10 steps appear in order (welcome → … → siriSetup → completion)
- [ ] Exit × visible on steps 1–8, hidden on welcome and completion
- [ ] Tapping × dismisses onboarding and does not re-show on next launch
- [ ] Siri screen shows all 4 phrases with mic icon
- [ ] Skip button on first-capture step advances to next step
- [ ] Replay (Settings → Replay Onboarding): firstCapture is skipped, siriSetup still appears, exit still works
- [ ] Shiny Thoughts step shows "Shiny Thoughts" title (not "Coming Soon")