### PR TITLE
fix: black TextEditor background on dark mode devices in onboarding

### DIFF
--- a/Sources/UI/Onboarding/Steps/FirstCaptureStepView.swift
+++ b/Sources/UI/Onboarding/Steps/FirstCaptureStepView.swift
@@ -97,6 +97,7 @@ struct CaptureScreenContent: View {
                     VStack(alignment: .leading, spacing: 8) {
                         TextEditor(text: $viewModel.thoughtContent)
                             .frame(minHeight: 120)
+                            .scrollContentBackground(.hidden)
                             .padding(12)
                             .background(theme.surfaceColor)
                             .cornerRadius(12)


### PR DESCRIPTION
## Problem
On devices running dark mode, the TextEditor in the first-capture onboarding step showed a black background with near-invisible text. Reported by beta tester.

## Root Cause
`TextEditor` (UIKit `UITextView` under the hood) renders its own intrinsic scroll background using the system color scheme, ignoring SwiftUI's `.background()` modifier. Without `.scrollContentBackground(.hidden)`, the text view paints black over `theme.surfaceColor` when the device is in dark mode — even when the onboarding screen forces `.preferredColorScheme(.light)`.

## Fix
Added `.scrollContentBackground(.hidden)` to the `TextEditor` in `CaptureScreenContent`. This is the same fix already present in `CaptureScreen.swift` (lines 207, 254) and `DetailScreen.swift` (line 282) — the onboarding's inline copy of the capture UI was the only place it was missing.

## Test Plan
- [ ] Open onboarding on a device/simulator set to dark mode
- [ ] Reach the first-capture step — TextEditor should show `surfaceColor` background, not black
- [ ] Verify text is readable
- [ ] Verify same screen looks correct in light mode