### PR TITLE
fix: persona picker — tap previews, confirm button commits selection

### DIFF
--- a/Sources/UI/Onboarding/Steps/PersonaPickerStepView.swift
+++ b/Sources/UI/Onboarding/Steps/PersonaPickerStepView.swift
@@ -69,13 +69,29 @@ struct PersonaPickerStepView: View {
                                 // No detail sheet in onboarding
                             },
                             onSetDefault: {
-                                viewModel.selectPersona(persona)
+                                // Preview only — does not advance. Confirm button below commits the choice.
+                                viewModel.selectedPersona = persona
                             }
                         )
                     }
                 }
                 .padding(.horizontal, 24)
+
+                // Confirm button — commits selection and advances
+                Button {
+                    viewModel.selectPersona(viewModel.selectedPersona)
+                } label: {
+                    Text("Choose \(viewModel.selectedPersona.name)")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.accentColor)
+                        .foregroundStyle(.white)
+                        .clipShape(RoundedRectangle(cornerRadius: 14))
+                }
+                .padding(.horizontal, 24)
                 .padding(.bottom, 40)
+                .animation(.easeInOut(duration: 0.2), value: viewModel.selectedPersona.id)
             }
         }
         .scrollContentBackground(.hidden)


### PR DESCRIPTION
## Problem
Tapping a squirrel card in onboarding immediately saved that persona and auto-advanced, giving users no chance to browse all options before committing.

## Change
- Tapping a card now updates the preview only (greeting text and avatar update, card highlights) — no save, no advance
- A "Choose [Persona Name]" button appears at the bottom, updating its label as the user browses
- Tapping the button calls `selectPersona()` to persist the choice and advance

## Test Plan
- [ ] Tap each squirrel card — greeting preview and highlight update, screen does not advance
- [ ] Button label updates to match the currently highlighted persona
- [ ] Tapping the button advances to the next step with the selected persona saved
- [ ] Replay flow works the same way