### PR TITLE
fix: compound noun phrase detection in fallback tag generation

### DIFF
--- a/Sources/Services/Intelligence/ClassificationService.swift
+++ b/Sources/Services/Intelligence/ClassificationService.swift
@@ -394,9 +394,9 @@ actor ClassificationService: ClassificationServiceProtocol, DomainServiceProtoco
             }
         }
 
-        // Extract keywords
-        let lemmas = await nlpService.lemmatize(content)
-        let keywords = extractKeywords(from: lemmas)
+        // Extract tag candidates — consecutive nouns are compounded (e.g. "server-issue")
+        let candidates = await nlpService.extractTagCandidates(content)
+        let keywords = extractKeywords(from: candidates)
 
         for keyword in keywords {
             let normalized = normalizeTag(keyword)
@@ -412,7 +412,7 @@ actor ClassificationService: ClassificationServiceProtocol, DomainServiceProtoco
             .map { $0 }
     }
 
-    private func extractKeywords(from lemmas: [String]) -> [String] {
+    private func extractKeywords(from candidates: [String]) -> [String] {
         // Filter out common stop words
         let stopWords = Set([
             "the", "a", "an", "and", "or", "but", "in", "on", "at", "to", "for",
@@ -425,10 +425,18 @@ actor ClassificationService: ClassificationServiceProtocol, DomainServiceProtoco
             "being", "doing", "having", "getting"
         ])
 
-        return lemmas
-            .filter { !stopWords.contains($0) }
-            .filter { $0.count > 2 } // At least 3 characters
-            .filter { $0.allSatisfy { $0.isLetter } } // Letters only
+        return candidates.filter { candidate in
+            if candidate.contains("-") {
+                // Compound noun phrase — validate each component
+                let parts = candidate.components(separatedBy: "-")
+                return parts.count >= 2
+                    && parts.allSatisfy { !stopWords.contains($0) && $0.count > 2 && $0.allSatisfy { $0.isLetter } }
+            }
+            // Single word — standard filters
+            return !stopWords.contains(candidate)
+                && candidate.count > 2
+                && candidate.allSatisfy { $0.isLetter }
+        }
     }
 
     private func normalizeTag(_ tag: String) -> String {

--- a/Sources/Services/Intelligence/NLPService.swift
+++ b/Sources/Services/Intelligence/NLPService.swift
@@ -29,6 +29,12 @@ protocol NLPServiceProtocol: ServiceProtocol {
 
     /// Tokenizes text into words
     func tokenize(_ text: String) async -> [String]
+
+    /// Extracts tag candidates, joining consecutive nouns as compound phrases.
+    ///
+    /// For example: "server issues" → ["server-issue"] instead of ["server", "issue"].
+    /// Non-noun content words are returned as individual lemmatized tokens.
+    func extractTagCandidates(_ text: String) async -> [String]
 }
 
 // MARK: - NLP Service
@@ -201,6 +207,51 @@ actor NLPService: NLPServiceProtocol, DomainServiceProtocol {
         return tokens
     }
 
+    // MARK: - Tag Candidates
+
+    /// Extracts tag candidates, joining consecutive nouns as compound phrases.
+    ///
+    /// Uses a single NLTagger pass with both `.lexicalClass` and `.lemma` schemes.
+    /// Consecutive nouns are lemmatized and joined with hyphens (e.g. "server-issue").
+    /// Non-noun tokens are returned as individual lemmatized words.
+    func extractTagCandidates(_ text: String) async -> [String] {
+        guard !text.isEmpty else { return [] }
+
+        let tagger = NLTagger(tagSchemes: [.lexicalClass, .lemma])
+        tagger.string = text
+
+        var result: [String] = []
+        var currentNounPhrase: [String] = []
+
+        let options: NLTagger.Options = [.omitPunctuation, .omitWhitespace]
+
+        tagger.enumerateTags(in: text.startIndex..<text.endIndex, unit: .word, scheme: .lexicalClass, options: options) { tag, tokenRange in
+            let lemmaTag = tagger.tag(at: tokenRange.lowerBound, unit: .word, scheme: .lemma)
+            let word = (lemmaTag?.rawValue ?? String(text[tokenRange])).lowercased()
+
+            if tag == .noun {
+                currentNounPhrase.append(word)
+            } else {
+                if !currentNounPhrase.isEmpty {
+                    result.append(currentNounPhrase.count > 1
+                        ? currentNounPhrase.joined(separator: "-")
+                        : currentNounPhrase[0])
+                    currentNounPhrase = []
+                }
+                result.append(word)
+            }
+            return true
+        }
+
+        if !currentNounPhrase.isEmpty {
+            result.append(currentNounPhrase.count > 1
+                ? currentNounPhrase.joined(separator: "-")
+                : currentNounPhrase[0])
+        }
+
+        return result
+    }
+
     // MARK: - Service Protocol
 
     func initialize() async throws {
@@ -290,5 +341,9 @@ actor MockNLPService: NLPServiceProtocol {
 
     func tokenize(_ text: String) async -> [String] {
         mockTokens
+    }
+
+    func extractTagCandidates(_ text: String) async -> [String] {
+        mockLemmas
     }
 }


### PR DESCRIPTION
## Summary
- Adds `extractTagCandidates()` to `NLPService` / `NLPServiceProtocol` — single NLTagger pass using `.lexicalClass` + `.lemma` schemes that joins consecutive nouns into hyphenated compound tags
- `ClassificationService.generateTags()` now calls `extractTagCandidates()` instead of `lemmatize()`
- `extractKeywords(from:)` updated to accept hyphenated compounds (validates each component separately)
- `MockNLPService` updated with stub implementation

## Test Plan
- [ ] On iPhone 14 simulator (no Apple Intelligence): capture "The server issues are causing problems with the API" → expected tags include "server-issue", not individual "server" + "issue"
- [ ] Single nouns still tag correctly: "I need to schedule a meeting" → "meeting" tag present
- [ ] Foundation Models path unaffected (change is in the fallback path only)

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)