### PR TITLE
feat: close classification feedback loop with local bias store

### DIFF
--- a/PersonalAI.xcodeproj/project.pbxproj
+++ b/PersonalAI.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		A0000001000000000000143 /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0000001000000000000144 /* NetworkMonitor.swift */; };
 		A0000001000000000000151 /* NLPService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0000001000000000000152 /* NLPService.swift */; };
 		A0000001000000000000153 /* ClassificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0000001000000000000154 /* ClassificationService.swift */; };
+		A0000001000000000000155 /* ClassificationBiasStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0000001000000000000156 /* ClassificationBiasStore.swift */; };
 		A0000001000000000000161 /* ThoughtService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0000001000000000000162 /* ThoughtService.swift */; };
 		A0000001000000000000163 /* TaskService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0000001000000000000164 /* TaskService.swift */; };
 		A0000001000000000000171 /* ContextService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0000001000000000000172 /* ContextService.swift */; };
@@ -186,6 +187,7 @@
 		A0000001000000000000144 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
 		A0000001000000000000152 /* NLPService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NLPService.swift; sourceTree = "<group>"; };
 		A0000001000000000000154 /* ClassificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassificationService.swift; sourceTree = "<group>"; };
+		A0000001000000000000156 /* ClassificationBiasStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassificationBiasStore.swift; sourceTree = "<group>"; };
 		A0000001000000000000162 /* ThoughtService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThoughtService.swift; sourceTree = "<group>"; };
 		A0000001000000000000164 /* TaskService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskService.swift; sourceTree = "<group>"; };
 		A0000001000000000000172 /* ContextService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextService.swift; sourceTree = "<group>"; };
@@ -456,6 +458,7 @@
 			children = (
 				A0000001000000000000152 /* NLPService.swift */,
 				A0000001000000000000154 /* ClassificationService.swift */,
+				A0000001000000000000156 /* ClassificationBiasStore.swift */,
 				A7EFEB1FB682981ADA7E6A39 /* InsightsAnalyzer.swift */,
 				A1B77D0E2F3E4A1200F8D6B4 /* ContextEnrichmentService.swift */,
 				A1803D472F25BDFD0071D950 /* DateTimeParsingService.swift */,
@@ -736,6 +739,7 @@
 				A0000001000000000000143 /* NetworkMonitor.swift in Sources */,
 				A0000001000000000000151 /* NLPService.swift in Sources */,
 				A0000001000000000000153 /* ClassificationService.swift in Sources */,
+				A0000001000000000000155 /* ClassificationBiasStore.swift in Sources */,
 				A1A6326A2F33A8B900DA552B /* ConversationScreen.swift in Sources */,
 				A1A6326B2F33A8B900DA552B /* AppleIntelligenceRequiredView.swift in Sources */,
 				ABAF86190408267B09159634 /* InsightsAnalyzer.swift in Sources */,

--- a/Sources/Services/Intelligence/ClassificationBiasStore.swift
+++ b/Sources/Services/Intelligence/ClassificationBiasStore.swift
@@ -1,0 +1,162 @@
+//
+//  ClassificationBiasStore.swift
+//  STASH
+//
+//  Local bias layer on top of CoreData fine-tuning data (Issue #48 Option A).
+//  Records negative feedback signals per content pattern and applies them
+//  during heuristic classification to avoid repeated misclassifications.
+//
+//  Compatible with future Option B (model fine-tuning): this store is
+//  independent of FineTuningData CoreData records and can be retired when
+//  a trained model replaces the heuristic path.
+//
+
+import Foundation
+
+// MARK: - Classification Correction
+
+struct ClassificationCorrection: Codable {
+    /// First 5 words of thought content, lowercased — used as the pattern key.
+    let pattern: String
+
+    /// The `ClassificationType.rawValue` that was wrong for this pattern.
+    let penalizedType: String
+
+    /// The `ClassificationType.rawValue` the user explicitly corrected to, if known.
+    var preferredType: String?
+
+    /// Increases with repeated negative feedback; decreases with positive feedback.
+    var weight: Double
+
+    let createdAt: Date
+}
+
+// MARK: - Classification Bias Store
+
+/// Lightweight `UserDefaults`-backed store that records classification correction signals.
+///
+/// ## How it works
+/// - 👎 feedback increments the penalty weight for a (pattern, type) pair.
+/// - Explicit type edits additionally record the `preferredType`.
+/// - 👍 feedback decrements weight; entry is removed when weight reaches zero.
+/// - `ClassificationService.classifyType` checks this store before returning
+///   a type and skips penalized types (weight ≥ 2.0).
+///
+/// ## Maintenance
+/// - Capped at 200 entries; oldest are evicted when over limit.
+/// - Entries older than 90 days are pruned on every write.
+final class ClassificationBiasStore {
+    static let shared = ClassificationBiasStore()
+
+    private let userDefaultsKey = "classificationBiasCorrections"
+    private let maxEntries = 200
+    private let decayDays: Double = 90
+
+    /// Minimum weight before a penalty is applied during classification.
+    let applyThreshold: Double = 2.0
+
+    private init() {}
+
+    // MARK: - Pattern Extraction
+
+    /// Extracts a stable pattern key from thought content (first 5 words, lowercased).
+    static func extractPattern(from content: String) -> String {
+        content.lowercased()
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .prefix(5)
+            .joined(separator: " ")
+    }
+
+    // MARK: - Queries
+
+    /// Returns the accumulated penalty weight for a given pattern + type pair.
+    func penaltyWeight(for pattern: String, type: String) -> Double {
+        load().first { $0.pattern == pattern && $0.penalizedType == type }?.weight ?? 0.0
+    }
+
+    /// Returns the user-confirmed preferred type for a pattern, if one has been recorded.
+    func preferredType(for pattern: String, penalizedType: String) -> String? {
+        load().first { $0.pattern == pattern && $0.penalizedType == penalizedType }?.preferredType
+    }
+
+    // MARK: - Recording Signals
+
+    /// Records a negative feedback signal for the given pattern + type.
+    ///
+    /// Call when the user gives 👎 feedback, or when a type edit is saved.
+    /// Pass `preferredType` when the user has explicitly selected the correct type.
+    func record(pattern: String, penalizedType: String, preferredType: String? = nil) {
+        var corrections = load()
+
+        if let index = corrections.firstIndex(where: {
+            $0.pattern == pattern && $0.penalizedType == penalizedType
+        }) {
+            corrections[index].weight += 1.0
+            if let preferred = preferredType {
+                corrections[index].preferredType = preferred
+            }
+        } else {
+            corrections.append(ClassificationCorrection(
+                pattern: pattern,
+                penalizedType: penalizedType,
+                preferredType: preferredType,
+                weight: 1.0,
+                createdAt: Date()
+            ))
+        }
+
+        save(corrections)
+        trim()
+    }
+
+    /// Reduces the penalty weight for a pattern + type pair (positive feedback signal).
+    ///
+    /// Call when the user gives 👍 feedback on a thought. Removes the entry when
+    /// weight reaches zero.
+    func reinforce(pattern: String, penalizedType: String) {
+        var corrections = load()
+
+        guard let index = corrections.firstIndex(where: {
+            $0.pattern == pattern && $0.penalizedType == penalizedType
+        }) else { return }
+
+        corrections[index].weight = max(0, corrections[index].weight - 0.5)
+        if corrections[index].weight <= 0 {
+            corrections.remove(at: index)
+        }
+
+        save(corrections)
+    }
+
+    // MARK: - Maintenance
+
+    private func trim() {
+        var corrections = load()
+        let cutoff = Date().addingTimeInterval(-decayDays * 86400)
+
+        corrections.removeAll { $0.createdAt < cutoff }
+
+        if corrections.count > maxEntries {
+            corrections = Array(
+                corrections.sorted { $0.createdAt > $1.createdAt }.prefix(maxEntries)
+            )
+        }
+
+        save(corrections)
+    }
+
+    // MARK: - Persistence
+
+    private func load() -> [ClassificationCorrection] {
+        guard let data = UserDefaults.standard.data(forKey: userDefaultsKey),
+              let corrections = try? JSONDecoder().decode([ClassificationCorrection].self, from: data)
+        else { return [] }
+        return corrections
+    }
+
+    private func save(_ corrections: [ClassificationCorrection]) {
+        guard let data = try? JSONEncoder().encode(corrections) else { return }
+        UserDefaults.standard.set(data, forKey: userDefaultsKey)
+    }
+}

--- a/Sources/Services/Intelligence/ClassificationBiasStore.swift
+++ b/Sources/Services/Intelligence/ClassificationBiasStore.swift
@@ -45,7 +45,7 @@ struct ClassificationCorrection: Codable {
 /// ## Maintenance
 /// - Capped at 200 entries; oldest are evicted when over limit.
 /// - Entries older than 90 days are pruned on every write.
-final class ClassificationBiasStore {
+final class ClassificationBiasStore: @unchecked Sendable {
     static let shared = ClassificationBiasStore()
 
     private let userDefaultsKey = "classificationBiasCorrections"

--- a/Sources/Services/Intelligence/ClassificationService.swift
+++ b/Sources/Services/Intelligence/ClassificationService.swift
@@ -218,28 +218,37 @@ actor ClassificationService: ClassificationServiceProtocol, DomainServiceProtoco
 
     private func classifyType(_ content: String) async -> ClassificationType {
         let lowercased = content.lowercased()
+        let pattern = ClassificationBiasStore.extractPattern(from: lowercased)
+        let bias = ClassificationBiasStore.shared
 
-        // Check for reminder indicators
-        if containsReminderIndicators(lowercased) {
-            return .reminder
+        // Ordered candidates matching original heuristic priority.
+        // The bias store can skip a penalized type and jump to the next match,
+        // or return an explicit preferred type if the user recorded one via a type edit.
+        let candidates: [(ClassificationType, Bool)] = [
+            (.reminder, containsReminderIndicators(lowercased)),
+            (.event, containsEventIndicators(lowercased)),
+            (.question, isQuestion(lowercased)),
+            (.idea, containsIdeaIndicators(lowercased)),
+            (.note, true)
+        ]
+
+        for (type, matches) in candidates {
+            guard matches else { continue }
+
+            if bias.penaltyWeight(for: pattern, type: type.rawValue) >= bias.applyThreshold {
+                // Type is penalized — return explicit preferred type if known
+                if let preferredRaw = bias.preferredType(for: pattern, penalizedType: type.rawValue),
+                   let preferred = ClassificationType(rawValue: preferredRaw) {
+                    NSLog("🎯 Bias correction: \(type.rawValue) → \(preferred.rawValue) for '\(pattern)'")
+                    return preferred
+                }
+                // No preferred type recorded yet — skip to next candidate
+                continue
+            }
+
+            return type
         }
 
-        // Check for event indicators
-        if containsEventIndicators(lowercased) {
-            return .event
-        }
-
-        // Check for question indicators
-        if isQuestion(lowercased) {
-            return .question
-        }
-
-        // Check for idea indicators
-        if containsIdeaIndicators(lowercased) {
-            return .idea
-        }
-
-        // Default to note
         return .note
     }
 

--- a/Sources/Services/Orchestration/FineTuningService.swift
+++ b/Sources/Services/Orchestration/FineTuningService.swift
@@ -68,7 +68,7 @@ protocol FineTuningServiceProtocol: OrchestrationServiceProtocol {
     func trackEdited(_ thoughtId: UUID) async throws
 
     /// Tracks user feedback on classification
-    func trackUserFeedback(thoughtId: UUID, isPositive: Bool, correction: String?) async throws
+    func trackUserFeedback(thoughtId: UUID, feedbackType: UserFeedback.FeedbackType, correction: String?) async throws
 
     /// Calculates reward signal for a fine-tuning data point
     func calculateReward(_ data: FineTuningData) -> Double
@@ -435,14 +435,13 @@ actor FineTuningService: FineTuningServiceProtocol {
     }
 
     /// Tracks user feedback on classification.
-    func trackUserFeedback(thoughtId: UUID, isPositive: Bool, correction: String?) async throws {
+    func trackUserFeedback(thoughtId: UUID, feedbackType: UserFeedback.FeedbackType, correction: String?) async throws {
         guard configuration.features.enableFineTuningTracking else { return }
 
         guard let data = try await repository.fetch(thoughtId: thoughtId) else {
             return
         }
 
-        let feedbackType: UserFeedback.FeedbackType = isPositive ? .helpful : .not_helpful
         let feedback = UserFeedback(
             type: feedbackType,
             comment: correction,
@@ -621,7 +620,7 @@ actor MockFineTuningService: FineTuningServiceProtocol {
     func trackDeleted(_ thoughtId: UUID) async throws {}
     func trackViewed(_ thoughtId: UUID) async throws {}
     func trackEdited(_ thoughtId: UUID) async throws {}
-    func trackUserFeedback(thoughtId: UUID, isPositive: Bool, correction: String?) async throws {}
+    func trackUserFeedback(thoughtId: UUID, feedbackType: UserFeedback.FeedbackType, correction: String?) async throws {}
 
     func calculateReward(_ data: FineTuningData) -> Double {
         0.75

--- a/Sources/Services/Orchestration/FineTuningService.swift
+++ b/Sources/Services/Orchestration/FineTuningService.swift
@@ -429,6 +429,11 @@ actor FineTuningService: FineTuningServiceProtocol {
         try await repository.update(updated)
     }
 
+    /// Returns previously stored feedback for a thought, if any.
+    func getFeedback(for thoughtId: UUID) async -> UserFeedback? {
+        (try? await repository.fetch(thoughtId: thoughtId))?.userFeedback
+    }
+
     /// Tracks user feedback on classification.
     func trackUserFeedback(thoughtId: UUID, isPositive: Bool, correction: String?) async throws {
         guard configuration.features.enableFineTuningTracking else { return }

--- a/Sources/UI/Screens/DetailScreen.swift
+++ b/Sources/UI/Screens/DetailScreen.swift
@@ -152,6 +152,7 @@ struct DetailScreen: View {
         }
         .task {
             await viewModel.loadRelatedThoughts()
+            await viewModel.loadFeedback()
             await loadConversationCount()
         }
         .onAppear {

--- a/Sources/UI/ViewModels/DetailViewModel.swift
+++ b/Sources/UI/ViewModels/DetailViewModel.swift
@@ -180,7 +180,7 @@ final class DetailViewModel {
             do {
                 try await fineTuningService.trackUserFeedback(
                     thoughtId: thought.id,
-                    isPositive: type == .helpful,
+                    feedbackType: type,
                     correction: comment
                 )
             } catch {

--- a/Sources/UI/ViewModels/DetailViewModel.swift
+++ b/Sources/UI/ViewModels/DetailViewModel.swift
@@ -182,6 +182,16 @@ final class DetailViewModel {
                 // Silently fail - feedback is best-effort
             }
 
+            // Update local bias store
+            if let currentType = thought.classification?.type {
+                let pattern = ClassificationBiasStore.extractPattern(from: thought.content)
+                if type == .not_helpful {
+                    ClassificationBiasStore.shared.record(pattern: pattern, penalizedType: currentType.rawValue)
+                } else if type == .helpful {
+                    ClassificationBiasStore.shared.reinforce(pattern: pattern, penalizedType: currentType.rawValue)
+                }
+            }
+
             isSubmittingFeedback = false
         }
     }
@@ -268,11 +278,20 @@ final class DetailViewModel {
                 // Save
                 self.thought = try await thoughtService.update(updated)
 
-                // Analytics: only fires if save succeeded
+                // Analytics + bias correction: only fire if save succeeded
                 if let newType = editedClassificationType,
                    let originalType = thought.classification?.type,
                    newType != originalType {
                     AnalyticsService.shared.track(.classificationOverridden(from: originalType.rawValue, to: newType.rawValue))
+
+                    // Record explicit type correction so future captures of similar
+                    // content get the preferred type applied by ClassificationBiasStore
+                    let pattern = ClassificationBiasStore.extractPattern(from: trimmedContent)
+                    ClassificationBiasStore.shared.record(
+                        pattern: pattern,
+                        penalizedType: originalType.rawValue,
+                        preferredType: newType.rawValue
+                    )
                 }
 
                 // Exit edit mode

--- a/Sources/UI/ViewModels/DetailViewModel.swift
+++ b/Sources/UI/ViewModels/DetailViewModel.swift
@@ -165,6 +165,11 @@ final class DetailViewModel {
 
     // MARK: - Feedback Actions
 
+    /// Loads previously stored feedback from CoreData so the UI reflects it on return.
+    func loadFeedback() async {
+        userFeedback = await fineTuningService.getFeedback(for: thought.id)
+    }
+
     /// Provides feedback on the thought/classification
     func provideFeedback(_ type: UserFeedback.FeedbackType, comment: String? = nil) {
         let feedback = UserFeedback(type: type, comment: comment, timestamp: Date())


### PR DESCRIPTION
## Summary
- New `ClassificationBiasStore` — `UserDefaults`-backed, no new CoreData entities
- 👎 feedback increments penalty weight for a (pattern, type) pair
- Explicit type edit in Detail screen additionally records the `preferredType`
- 👍 feedback decrements weight; entry removed at zero
- `ClassificationService.classifyType` skips types with penalty ≥ 2.0 and jumps to preferred type if known
- Store capped at 200 entries, entries older than 90 days are pruned on each write
- `FineTuningData` CoreData records completely untouched — compatible with future Option B fine-tuning

## Test Plan
- [ ] Capture a thought that gets misclassified (e.g. "pick up dry cleaning" → Idea)
- [ ] Give 👎 twice on the detail screen
- [ ] Capture a similar thought ("pick up milk") — confirm it no longer gets classified as Idea
- [ ] Give 👍 on a correctly classified thought — confirm it doesn't break anything
- [ ] Explicitly change a classification type via edit — capture similar content and confirm the new type is applied
- [ ] Foundation Models path (iPhone 15 Pro / 16) unaffected — no bias store calls in that path

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)