### PR TITLE
fix: acorn balance in info bubble always showed 0

### DIFF
--- a/Sources/UI/Screens/BrowseScreen.swift
+++ b/Sources/UI/Screens/BrowseScreen.swift
@@ -132,7 +132,7 @@ struct BrowseScreen: View {
             }
             .task {
                 await viewModel.loadThoughts()
-                currentAcornBalance = await currentAcornBalance
+                currentAcornBalance = await acornLedger.currentBalance
             }
             .confirmationDialog(
                 "Delete this thought?",


### PR DESCRIPTION
## Summary
- `BrowseScreen.swift` line 135 had `currentAcornBalance = await currentAcornBalance` — a self-assignment that left the balance stuck at 0
- Fixed to `await acornLedger.currentBalance`

## Test Plan
- [ ] Launch app — info bubble shows correct acorn count
- [ ] Earn acorns (capture a thought), return to browse — count reflects new balance

🤖 Generated with [Claude Code](https://claude.com/claude-code)